### PR TITLE
Fixing typing support for python 3.8 ifeval util.py

### DIFF
--- a/tools/benchmarks/llm_eval_harness/meta_eval/meta_template/ifeval/utils.py
+++ b/tools/benchmarks/llm_eval_harness/meta_eval/meta_template/ifeval/utils.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, List
 
 from lm_eval.tasks.ifeval import instructions_registry
 
@@ -7,18 +7,18 @@ from lm_eval.tasks.ifeval import instructions_registry
 @dataclasses.dataclass
 class InputExample:
     key: int
-    instruction_id_list: list[str]
+    instruction_id_list: List[str]
     prompt: str
-    kwargs: list[Dict[str, Optional[Union[str, int]]]]
+    kwargs: List[Dict[str, Optional[Union[str, int]]]]
 
 
 @dataclasses.dataclass
 class OutputExample:
-    instruction_id_list: list[str]
+    instruction_id_list: List[str]
     prompt: str
     response: str
     follow_all_instructions: bool
-    follow_instruction_list: list[bool]
+    follow_instruction_list: List[bool]
 
 
 def test_instruction_following_strict(
@@ -32,7 +32,7 @@ def test_instruction_following_strict(
     for index, instruction_id in enumerate(instruction_list):
         instruction_cls = instructions_registry.INSTRUCTION_DICT[instruction_id]
         instruction = instruction_cls(instruction_id)
-                
+
         # Remove None values from kwargs to avoid unexpected keyword argument errors in build_description method.
         kwargs = {k: v for k, v in inp.kwargs[index].items() if v}
         instruction.build_description(**kwargs)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Please include a good title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

-->

<!-- Remove if not applicable -->

Fixes python 3.8 support when using `typing` in  `tools/benchmarks/llm_eval_harness/meta_eval/meta_template/ifeval/utils.py`, in particular importing and using List (https://docs.python.org/3.8/library/typing.html).

## Feature/Issue validation/testing

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/llama-recipes/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?  
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
